### PR TITLE
Use operation's cache

### DIFF
--- a/app/components/workflow-task.js
+++ b/app/components/workflow-task.js
@@ -18,7 +18,7 @@ export default Ember.Component.extend({
     el.css('left', task.left);
 
     Ember.run(() => {
-      this.get('store').findRecord('operation', task.operation.id).then(op => {
+      this.get('store').findRecord('operation', task.operation.id, {backgroundReload: false}).then(op => {
         let fn = function(a, b) { return a.order > b.order; };
         let input = op.get('ports').filter(p => p.type === 'INPUT').sort(fn);
         let output = op.get('ports').filter(p => p.type === 'OUTPUT').sort(fn);


### PR DESCRIPTION
This commit fix #41 by telling ember it should use operation's cache version. This should be default but is still a work in progress on ember-data: https://github.com/emberjs/data/issues/4381