### PR TITLE
Use .env.production when setting ENV.thorn

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -48,12 +48,8 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    ENV.thorn = 'http://thorn.speed.dcc.ufmg.br';
+    ENV.thorn = process.env.THORN || 'http://thorn.speed.dcc.ufmg.br';
   }
-  ENV['ember-simple-auth'] = {
-    authorizer: 'authorizer:devise',
-    routeAfterAuthentication: '/home/workflows'
-  };
 
   return ENV;
 };


### PR DESCRIPTION
If the .env.production file does not exists it will use the default
address for production